### PR TITLE
set displayname if not already set

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ docker run -d \
 	bonukai/pushmatrix
 ```
 
+If your server doesn't support registration of new users, but you have access to the command line, you can still use this feature. Calculate the internal user name for the topics you plan to use. In this example for the topic `doorbell`:
+
+```
+echo -n "doorbell" | base64 
+ZG9vcmJlbGw=
+```
+
+The internal username for `doorbell` will be `pushmatrix_ZG9vcmJlbGw=`. You can create this user with the same password that you use for the general pushmatrix user. For Synapse the command looks like this:
+
+```
+register_new_matrix_user -u pushmatrix_ZG9vcmJlbGw= -p password -c /data/homeserver.yaml https://matrix.example.org
+```
+
+When you use the topic for the first time, pushmatrix will set a more user-friendly displayname for that user - and also an avatar image if you put an appropriately named image into the `avatar/` folder.
+
 ### Authentication
 
 Access to the API can be limited by providing APP_TOKEN environment variable

--- a/pushmatrix.py
+++ b/pushmatrix.py
@@ -434,6 +434,11 @@ async def getClient(title: str):
 
         await newClient.set_displayname(title)
 
+    res_displayname = await newClient.get_displayname()
+    if res_displayname.displayname.startswith(USER_PREFIX):
+        print(f"Setting displayname for user {userId}")
+        await newClient.set_displayname(title)
+
     if newClient.should_upload_keys:
         await newClient.keys_upload()
 


### PR DESCRIPTION
For security reasons my home server does not allow the registration of new users. However, I can register new users on the command line of my home server like this:
```
register_new_matrix_user -u pushmatrix_ZG9vcmJlbGw= -p t0ps3cr3t   -c /data/homeserver.yaml https://matrix.example.org
```
To get a nice display name, the code checks if the displayname still starts with USER_PREFIX. If that is the case set the displayname to the more human-friendly value.